### PR TITLE
feat: users should sign message to upload stems

### DIFF
--- a/components/StemUploadDialog.tsx
+++ b/components/StemUploadDialog.tsx
@@ -28,6 +28,7 @@ import type { IFileToUpload } from './StemDropzone'
 import StemDropzone from './StemDropzone'
 import styles from './StemUploadDialog.styles'
 import { useWeb3 } from './Web3Provider'
+import signMessage from '../utils/signMessage'
 
 const stemTypes = [
 	{
@@ -90,6 +91,9 @@ const StemUploadDialog = (props: StemUploadDialogProps): JSX.Element => {
 	// Other
 	const { NFTStore, currentUser, connected, handleConnectWallet } = useWeb3()
 	const disableUpload = file === null || stemName === '' || stemType === '' || loading
+	//Signing Message
+	const SIGNING_MSG =
+		'Sign this message to be able to upload this stem to Arbor. You are signing to verify that you are human.'
 
 	const handleClose = () => {
 		setStemName('')
@@ -118,6 +122,19 @@ const StemUploadDialog = (props: StemUploadDialogProps): JSX.Element => {
 
 		try {
 			setLoading(true)
+
+			// Check signature for user
+			let stemUploadSignature: any = localStorage.getItem('stemUploadSignature')
+			console.log('stemUploadSignature', stemUploadSignature)
+
+			if (stemUploadSignature === null) stemUploadSignature = JSON.stringify({})
+
+			stemUploadSignature = JSON.parse(stemUploadSignature)
+			if (typeof stemUploadSignature[currentUser.address] === 'undefined') {
+				const message = await signMessage(SIGNING_MSG)
+				stemUploadSignature[currentUser.address] = message
+				localStorage.setItem('stemUploadSignature', JSON.stringify(stemUploadSignature))
+			}
 
 			if (!uploadingOpen) setUploadingOpen(true)
 			setUploadingMsg('Uploading stem to NFT.storage...')


### PR DESCRIPTION
# General Changes

- User should sign message while uploading stems

## Developer Notes

- This signed message is stored in local storage. If the user signs this message already then the user is able to upload stems if not then the user should sign the message before uploading stems.
- All signed messages are stored using key-value pair (Address: Signed Message) in local storage.
 

---

## Author Checklist

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

## Reviewer Checklist

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  New third-party packages, if any, do not introduce potential security threats
- [ ]  There are no CI changes, or they have been OK’d by the devops team
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  There is at least one approval from the core team
- [ ]  Squash and merge has been checked
