### PR TITLE
fix: Multiples solos plays audio for wrong tracks.#193

### DIFF
--- a/components/ProjectDetails/ProjectDetails.tsx
+++ b/components/ProjectDetails/ProjectDetails.tsx
@@ -140,15 +140,11 @@ const ProjectDetails = (props: ProjectDetailsProps): JSX.Element | null => {
 	}
 
 	const handlePlay = () => {
-		stems.forEach(waveform => waveform.play())
+		stems.forEach(stem => stem.play())
 	}
 
-	//   const handlePause = () => {
-	// 	stems.forEach(waveform => waveform.pause());
-	//   };
-
-	const handleStopp = () => {
-		stems.forEach(waveform => waveform.stop())
+	const onStop = () => {
+		stems.forEach(stem => stem.stop())
 	}
 
 	const handleSolo = (idx: number) => {
@@ -478,15 +474,11 @@ const ProjectDetails = (props: ProjectDetailsProps): JSX.Element | null => {
 								details={stem}
 								onWavesInit={onWavesInit}
 								onFinish={() => setIsPlayingAll(false)}
-								// onSolo={handleSoloStem}
 								onNewFile={onNewFile}
-								// isStemDetails
-								// isQueued
 								onPlay={handlePlay}
 								onSolo={handleSolo}
 								onMute={handleMute}
-								// onSkipPrev
-								onStop={handleStopp}
+								onStop={onStop}
 								handleUnmuteAll={handleUnmuteAll}
 							/>
 						</Fragment>

--- a/components/StemPlayer.tsx
+++ b/components/StemPlayer.tsx
@@ -19,9 +19,11 @@ type StemPlayerProps = {
 	isQueued?: boolean
 	onPlay?: (idx: number) => any
 	onSolo?: (idx: number) => any
+	onMute?: (idx: number) => any
 	onSkipPrev?: () => any
 	onStop?: (idx: number) => any
 	onNewFile?: (newFileName: string, newFile: Blob) => void
+	handleUnmuteAll?: boolean
 }
 
 const StemPlayer = (props: StemPlayerProps): JSX.Element => {
@@ -34,11 +36,12 @@ const StemPlayer = (props: StemPlayerProps): JSX.Element => {
 		isQueued,
 		onPlay,
 		onSolo,
+		onMute,
 		onSkipPrev,
 		onStop,
 		onNewFile,
+		handleUnmuteAll,
 	} = props
-	const [wavesurfer, setWavesurfer] = useState<WaveSurfer>()
 	const [isMuted, setIsMuted] = useState<boolean>(false)
 	const [isSoloed, setIsSoloed] = useState<boolean>(false)
 	const [blob, setBlob] = useState<Blob>()
@@ -77,20 +80,25 @@ const StemPlayer = (props: StemPlayerProps): JSX.Element => {
 				if (onFinish) onFinish(idx, ws)
 			})
 
-			setWavesurfer(ws)
 			// Callback to the parent
 			onWavesInit(idx, ws)
 			return () => ws.destroy()
 		}
 	}, [blob, loadingBlob]) /* eslint-disable-line react-hooks/exhaustive-deps */
 
+	useEffect(() => {
+		setIsSoloed(false)
+	}, [handleUnmuteAll])
+
 	const toggleMute = () => {
 		setIsMuted(!isMuted)
-		wavesurfer?.setMute(!wavesurfer?.getMute())
+		setIsSoloed(false)
+		if (onMute) onMute(idx)
 	}
 
 	const toggleSolo = () => {
 		setIsSoloed(!isSoloed)
+		setIsMuted(false)
 		if (onSolo) onSolo(idx)
 	}
 


### PR DESCRIPTION
# General Changes

- Fixes "Bug Notes
In this [project](https://arbor.audio/projects/62c27135f8cc7ff069be9608), when selecting a solo, an incorrect sample plays.

Expected Behavior
Seems like the behavior should either be to only allow one track to be soloed at a time, or if two tracks are solo'ed only those two tracks should be playing."

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

- [ ]  The base branch is set to `main`
- [x]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [x]  The Github issue has been linked to the PR in the Development section
- [x]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

## Reviewer Checklist

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  New third-party packages, if any, do not introduce potential security threats
- [ ]  There are no CI changes, or they have been OK’d by the devops team
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  There is at least one approval from the core team
- [ ]  Squash and merge has been checked
